### PR TITLE
submenu fix for screen readers

### DIFF
--- a/style.css
+++ b/style.css
@@ -761,12 +761,12 @@ iframe {
 }
 
 #nav ul ul {
-	display: none;
+	display: block;
 	float: left;
 	margin: 0;
 	position: absolute;
 	top: 31px;
-	left: 0;
+	left: -9999px;
 	width: 200px;
 	z-index: 99999;
 }
@@ -835,7 +835,7 @@ iframe {
 }
 
 #nav ul li:hover > ul {
-	display: block;
+	left: 0;
 }
 
 @media only screen and (max-width: 480px) {
@@ -848,7 +848,7 @@ iframe {
 	}
 
 	#nav ul li:hover > ul {
-		display: none;
+		left: -9999px;
 	}
 }
 


### PR DESCRIPTION
display: none is honoured by some screen readers (e.g., Apple’s VoiceOver) which causes submenus to disappear entirely from the audio stream and become inaccessible. The use of the (ugly) -9999px hack fixes the problem.

Tested on Chrome & Safari on MacOSX, Firefox on Windows, but further testing might be needed. 

(This has also tested on Safari on the iPhone but since navigation is displayed differently this patch does not actually affect the iPhone.)
