### PR TITLE
Workaround for archive navigation display

### DIFF
--- a/style.css
+++ b/style.css
@@ -1830,6 +1830,16 @@ article .content { *zoom: 1; }
 }
 
 /**
+ * Archive navigation
+ */
+ 
+ ul > .post-nav {
+	margin-top: 15px;
+	border-top: 1px dashed #ccc;
+	padding-top: 15px;
+}
+ 
+/**
  * Author and date archives
  */
 


### PR DESCRIPTION
On the archive pages, the navigation (previous / later posts) is included in the &lt;ul&gt;&lt;/ul&gt; block surrounding the &lt;li&gt; entries.

I _think_ that is due to this code in `archive.php`:

```
<ul>
<?php get_template_part( 'loop', 'archive' ); ?>
</ul>
```

That will generate the navigation "in between", it seems.

As I've no time to fix the PHP code, I just added some whitespace - and a separator line - via CSS. It's a kludge, but it works for now.
