### PR TITLE
Remove separator from title now wp_title() is used

### DIFF
--- a/header.php
+++ b/header.php
@@ -7,7 +7,7 @@
 <!--[if (gt IE 9)|(gt IEMobile 7)|!(IEMobile)|!(IE)]><!--><html id="blaskan" class="no-js" <?php language_attributes(); ?>><!--<![endif]-->
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
-	<title><?php wp_title( '|', true, 'right' ); ?></title>
+	<title><?php wp_title( '' ); ?></title>
 	<?php wp_head(); ?>
 	<?php if ( is_singular() ) wp_enqueue_script( 'comment-reply' ); ?>
 </head>
@@ -19,4 +19,3 @@
 		  <?php echo blaskan_header_structure(); ?>
 		</header>
 		<!-- / #header -->
-


### PR DESCRIPTION
It looks a bit strange to have a separator with nothing the other side of it:

![screen shot 2015-04-25 at 20 05 31](https://cloud.githubusercontent.com/assets/3727684/7334267/7ce6e3f6-eb86-11e4-9461-72a1652910d8.png)

So I've passed an empty string to `wp_title()` instead. The second parameter defaults to `true` anyway, and the third is no longer needed with no separator :)
