### PR TITLE
Fixed deprecated eregi_replace

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -517,7 +517,7 @@ add_filter( 'the_permalink', 'blaskan_root_relative_permalinks' );
  */
 if ( ! function_exists( 'blaskan_remove_empty_read_more_span' ) ):
 function blaskan_remove_empty_read_more_span($content) {
-	return eregi_replace( "(<p><span id=\"more-[0-9]{1,}\"></span></p>)", "", $content );
+	return preg_replace( "(<p><span id=\"more-[0-9]{1,}\"></span></p>)", "", $content );
 }
 endif;
 add_filter( 'the_content', 'blaskan_remove_empty_read_more_span' );


### PR DESCRIPTION
After upgrading our server to the latest PHP version, the eregi_replace call (deprecated) crashed PHP, which resulted in the theme not loading fully (no content was loaded, pages returned blank).

This fixes that. I highly recommend merging this into the theme, since I suspect a lot of people will run into trouble on hosts upgrading their PHP version.
